### PR TITLE
Fix Version field validation: coerce string to int

### DIFF
--- a/custom_components/mycloud/config_flow.py
+++ b/custom_components/mycloud/config_flow.py
@@ -39,6 +39,6 @@ class MyCloudConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required("Host"): str,
             vol.Required("Username"): str,
             vol.Required("Password"): str,
-            vol.Required("Version"): vol.In([2, 5])
+            vol.Required("Version"): vol.All(vol.Coerce(int), vol.In([2, 5]))
         })
         return self.async_show_form(step_id="user", data_schema=schema)


### PR DESCRIPTION
## Summary
- The config flow form returns the Version value as a string (`"5"`), but `vol.In([2, 5])` expects an integer, causing `value must be one of [2,5]` error during setup.
- Fix: add `vol.Coerce(int)` before the `vol.In()` check.

## Test plan
- Set up the integration via UI, select Version 2 or 5 → no longer fails validation